### PR TITLE
Fix for issue #643

### DIFF
--- a/LINUX/README.txt
+++ b/LINUX/README.txt
@@ -28,7 +28,6 @@ and these Perl modules (from CPAN):
 - DBI
 - Email::MIME
 - Email::Sender
-- File::Slurp
 - JSON
 - Linux::Inotify2
 - List::MoreUtils

--- a/dist.ini
+++ b/dist.ini
@@ -47,7 +47,6 @@ DateTime::Format::Strptime = 0
 DBI              = 0
 Email::Sender    = 0
 Email::Stuffer   = 0
-File::Slurp      = 0
 JSON             = 0
 Linux::Inotify2  = 0
 List::MoreUtils  = 0

--- a/lib/Octopussy/App/Parser.pm
+++ b/lib/Octopussy/App/Parser.pm
@@ -13,8 +13,7 @@ Module with functions for octo_parser program
 use strict;
 use warnings;
 
-use File::Basename;
-use File::Slurp;
+use Path::Tiny;
 
 use AAT::Syslog;
 use Octopussy::App;
@@ -67,7 +66,7 @@ sub Write_Logfile
     {
         $logfile =~ s/(msg_\d\dh\d\d)_\d+/$1/;
         $logfile .= '.gz' if (($logfile !~ /^.+\.gz$/) && $compression);
-        Octopussy::FS::Create_Directory(dirname($logfile));
+        Octopussy::FS::Create_Directory(path($logfile)->parent->stringify);
         if ($compression &&
             (defined open my $FILEZIP, '|-', "gzip >> $logfile"))
         {
@@ -76,7 +75,7 @@ sub Write_Logfile
         }
         elsif (!$compression)
         {
-			write_file($logfile, { append => 1 }, @{$logs});
+			path($logfile)->append($logs);
         }
         else
         {

--- a/lib/Octopussy/App/Parser.pm
+++ b/lib/Octopussy/App/Parser.pm
@@ -75,7 +75,7 @@ sub Write_Logfile
         }
         elsif (!$compression)
         {
-			path($logfile)->append($logs);
+            path($logfile)->append($logs);
         }
         else
         {

--- a/lib/Octopussy/Plugin.pm
+++ b/lib/Octopussy/Plugin.pm
@@ -71,14 +71,14 @@ sub Init_All
     my $conf = shift;
 
 
-	# There is no err_mode => 'quiet' for Path::Tiny, so if we can't
-	# read the directory just return zero.
-	return 0 unless (-d $DIR_PLUGIN_MODULES and -r _);
-	
-	my @plugins = path($DIR_PLUGIN_MODULES)->children(qr/.+\.pm$/);
+    # There is no err_mode => 'quiet' for Path::Tiny, so if we can't
+    # read the directory just return zero.
+    return 0 unless (-d $DIR_PLUGIN_MODULES and -r _);
+
+    my @plugins = path($DIR_PLUGIN_MODULES)->children(qr/.+\.pm$/);
     foreach my $p (@plugins)
     {
-		$p = $p->basename;
+        $p = $p->basename;
         $p =~ s/\.pm$//;
         my $func = 'Octopussy::Plugin::' . $p . '::Init';
         &{$func}($conf);
@@ -137,9 +137,9 @@ sub Functions
 
     $dir_plugins ||= Octopussy::FS::Directory($DIR_PLUGIN);
 
-	return ()	if (! -r $dir_plugins);
+    return ()   if (! -r $dir_plugins);
 
-	my @files = path($dir_plugins)->children(qr/.+\.xml$/);
+    my @files = path($dir_plugins)->children(qr/.+\.xml$/);
     foreach my $f (@files)
     {
         my $conf = AAT::XML::Read($f);

--- a/lib/Octopussy/Plugin.pm
+++ b/lib/Octopussy/Plugin.pm
@@ -70,9 +70,15 @@ sub Init_All
 {
     my $conf = shift;
 
-    my @plugins = grep { /.+\.pm$/ } read_dir($DIR_PLUGIN_MODULES, err_mode => 'quiet');
+
+	# There is no err_mode => 'quiet' for Path::Tiny, so if we can't
+	# read the directory just return zero.
+	return 0 unless (-d $DIR_PLUGIN_MODULES and -r _);
+	
+	my @plugins = path($DIR_PLUGIN_MODULES)->children(qr/.+\.pm$/);
     foreach my $p (@plugins)
     {
+		$p = $p->basename;
         $p =~ s/\.pm$//;
         my $func = 'Octopussy::Plugin::' . $p . '::Init';
         &{$func}($conf);

--- a/lib/Octopussy/Plugin.pm
+++ b/lib/Octopussy/Plugin.pm
@@ -9,7 +9,7 @@ Octopussy::Plugin - Octopussy Plugin module
 use strict;
 use warnings;
 
-use File::Slurp;
+use Path::Tiny;
 use FindBin;
 
 use AAT::Syslog;
@@ -133,10 +133,10 @@ sub Functions
 
 	return ()	if (! -r $dir_plugins);
 
-    my @files = grep { /.+\.xml$/ } read_dir($dir_plugins);
+	my @files = path($dir_plugins)->children(qr/.+\.xml$/);
     foreach my $f (@files)
     {
-        my $conf = AAT::XML::Read("$dir_plugins/$f");
+        my $conf = AAT::XML::Read($f);
         push @functions,
             {plugin => $conf->{name}, functions => $conf->{function}}
             if (defined $conf->{function});


### PR DESCRIPTION
Convert Octopussy/Plugin.pm from File::Slurp to Path::Tiny.

Found two instances of File::Slurp::read_dir. Both can be changed to Path::Tiny::children, but we need to adjust for having the full path instead of just the basename. Also, there is no quiet mode for Path::Tiny, so we need an additional guard clause.

