### PR TITLE
Allow admin to ignore password restrictions

### DIFF
--- a/usr/share/octopussy/user_edit.asp
+++ b/usr/share/octopussy/user_edit.asp
@@ -7,11 +7,19 @@ my $login = $Request->QueryString('user') || $f->{login};
 my $type = $Request->QueryString('type') || $f->{type};
 my $error = undef;
 
-if ((defined $f->{update}) && ($Session->{AAT_ROLE} =~ /^admin$/i))
+
+if (defined $f->{update})
 {
-  my $pwd_check = AAT::User::Check_Password_Rules('Octopussy', $f->{password});
-  if ($pwd_check->{status} eq 'OK')
-  {
+	if ($Session->{AAT_ROLE} !~ /^admin$/i)
+	{
+		my $pwd_check = AAT::User::Check_Password_Rules('Octopussy', $f->{password});
+		if ($pwd_check->{status} ne 'OK')
+		{
+			$error = $pwd_check->{error};
+		}
+	}
+	if (!defined $error)
+	{
  	  AAT::User::Update('Octopussy', $f->{login}, $f->{type},
  		 { 	   password => $f->{password},
 			     language => $f->{AAT_Language},
@@ -19,11 +27,7 @@ if ((defined $f->{update}) && ($Session->{AAT_ROLE} =~ /^admin$/i))
 			      status => $f->{status}, }
 		          );
 	  $Response->Redirect('./user.asp');
-  }
-  else
-  {
-    $error = $pwd_check->{error};
-  }
+	}
 }
 %>
 <WebUI:PageTop title="_USER_PREFS" help="users" />

--- a/var/lib/octopussy/conf/password_policy.xml
+++ b/var/lib/octopussy/conf/password_policy.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Octopussy_password_policy>
-    <rule re=".{8,}" description="At least 8 caracters" />
+    <rule re=".{8,}" description="At least 8 characters" />
     <rule re="[A-Z]" description="At least 1 uppercase" />
     <rule re="[a-z]" description="At least 1 lowercase" />
     <rule re="\d" description="At least 1 digit" />


### PR DESCRIPTION
Allow admin to ignore password restrictions (necessary for changing LDAP account's roles)

With a clean install of the most recent .deb package, with just user LDAP configured, the admin account cannot set the role on any LDAP users - it shows "At least 8 caracters" each time (although LDAP users shouldn't have a password).

This patch will simply allow any administrator changes. It may not be the best solution, but it does appear to allow us to redefine roles.